### PR TITLE
perf: optimize get_individual_outcomes

### DIFF
--- a/src/results/interfaces/interfaces.jl
+++ b/src/results/interfaces/interfaces.jl
@@ -9,22 +9,29 @@ function get_observations(result::Result)
 end
 
 function get_individual_outcomes(results::Vector{Result})
-    # Initialize a dictionary to store interaction outcomes between individuals
-    individual_outcomes = Dict{Int, SortedDict{Int, Float64}}()
+    outcome_dicts = [get_individual_outcomes(result) for result in results]
+    # Initialize a dictionary of dictionaries to store the individual outcomes
+    # Pre-allocate the dictionary to avoid resizing
+    # The inner dictionary is indexed by the opposing individual's ID
+    # The outer dictionary is indexed by the individual's ID
+    ids = Set(id for od in outcome_dicts for id in keys(od))
+    individual_outcomes = Dict{Int, Dict{Int, Float64}}(
+                            id=>Dict{Int, Float64}()
+                            for id in ids)
 
-    for result in results
-        outcome_dict = get_individual_outcomes(result)
-        for (id, outcome) in outcome_dict
+    for (i, result) in enumerate(results)
+        for (id, outcome) in outcome_dicts[i]
             # The opposing individual's ID is the one not matching the current ID
-            opposing_id = setdiff(result.individual_ids, [id])[1]
-            
-            # If the key doesn't exist in `individual_outcomes`, initialize a new SortedDict 
-            # and add the outcome
-            get!(individual_outcomes, id, SortedDict{Int, Float64}())[opposing_id] = outcome
+            @inbounds opposing_id = result.individual_ids[1] == id ? result.individual_ids[2] : result.individual_ids[1]
+            @inbounds individual_outcomes[id][opposing_id] = outcome
         end
     end
+    # convert individual outcomes to sorteddict
+    sorted_individual_outcomes = Dict{Int, SortedDict{Int, Float64}}(
+        id => SortedDict(outcome_dict) 
+        for (id, outcome_dict) in individual_outcomes)
 
-    return individual_outcomes
+    return sorted_individual_outcomes
 end
 
 function get_observations(results::Vector{Result})


### PR DESCRIPTION
Sped up get_individual_outcomes for a vector of results by about 2x. The second column is the number of cummulative samples the profiler took during a run with pop sizes of 10,000x100. The optimized code is sampled 100k times less for the same config, and makes up 30% less of the run time. Total runtime for ten generations for my sorting network config went from 274 seconds to 182 seconds.

Unoptimized get_individual_outcomes profile:
```
Total: 211134
ROUTINE ======================== get_individual_outcomes(::Vector{CoEvo.Results.Result}) in /home/garbus/micromamba/envs/coevo/share/julia/dev/CoEvo/src/results/interfaces/interfaces.jl
       275     141081 (flat, cum) 66.82% of Total
         .          .     11:function get_individual_outcomes(results::Vector{Result})
         .          .     12:    # Initialize a dictionary to store interaction outcomes between individuals
         .          .     13:    individual_outcomes = Dict{Int, SortedDict{Int, Float64}}()
         .          .     14:
         .          .     15:    for result in results
         2      18622     16:        outcome_dict = get_individual_outcomes(result)
         .         85     17:        for (id, outcome) in outcome_dict
         .          .     18:            # The opposing individual's ID is the one not matching the current ID
       138      40856     19:            opposing_id = setdiff(result.individual_ids, [id])[1]
         .          .     20:            
         .          .     21:            # If the key doesn't exist in `individual_outcomes`, initialize a new SortedDict 
         .          .     22:            # and add the outcome
        33      80857     23:            get!(individual_outcomes, id, SortedDict{Int, Float64}())[opposing_id] = outcome
         1        256     24:        end
         .        304     25:    end
         .          .     26:
         .          .     27:    return individual_outcomes
         .          .     28:end
         .          .     29:
         .          .     30:function get_observations(results::Vector{Result})
```

Optimized get_individual_outcomes:

```
       132      42665 (flat, cum) 35.52% of Total
         .          .     11:function get_individual_outcomes(results::Vector{Result})
         .      10878     12:    outcome_dicts = [get_individual_outcomes(result) for result in results]
         .          .     13:    # Initialize a dictionary of dictionaries to store the individual outcomes
         .          .     14:    # Pre-allocate the dictionary to avoid resizing
         .          .     15:    # The inner dictionary is indexed by the opposing individual's ID
         .          .     16:    # The outer dictionary is indexed by the individual's ID
         .       1812     17:    ids = Set(id for od in outcome_dicts for id in keys(od))
         .         35     18:    individual_outcomes = Dict{Int, Dict{Int, Float64}}(
         .          .     19:                            id=>Dict{Int, Float64}()
         .          .     20:                            for id in ids)
         .          .     21:
         .          .     22:    for (i, result) in enumerate(results)
         .        821     23:        for (id, outcome) in outcome_dicts[i]
         .          .     24:            # The opposing individual's ID is the one not matching the current ID
       108       9934     25:            @inbounds opposing_id = result.individual_ids[1] == id ? result.individual_ids[2] : result.individual_ids[1]
        20       7298     26:            @inbounds individual_outcomes[id][opposing_id] = outcome
         .        259     27:        end
         .         27     28:    end
         .          .     29:    # convert individual outcomes to sorteddict
         .      11597     30:    sorted_individual_outcomes = Dict{Int, SortedDict{Int, Float64}}(
         .          .     31:        id => SortedDict(outcome_dict) 
         .          .     32:        for (id, outcome_dict) in individual_outcomes)
         .          .     33:
         .          .     34:    return sorted_individual_outcomes
         .          .     35:end
 ```
         